### PR TITLE
`extend` to `include`, target control and visibility filter

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,7 +32,7 @@ Lint/ConstantResolution:
 
 # `define_hook` is little too complex...
 Metrics/AbcSize:
-  Max: 25
+  Max: 30
 
 Metrics/ClassLength:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,8 +30,24 @@ Layout/MultilineAssignmentLayout:
 Lint/ConstantResolution:
   Enabled: false
 
+# `define_hook` is little too complex...
+Metrics/AbcSize:
+  Max: 25
+
+Metrics/ClassLength:
+  Exclude:
+    - 'test/**/*'
+
+# `define_hook` is little too complex...
+Metrics/CyclomaticComplexity:
+  Max: 10
+
 Metrics/MethodLength:
   Max: 15
+
+# `define_hook` is little too complex...
+Metrics/PerceivedComplexity:
+  Max: 10
 
 Security/Eval:
   Exclude:

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Or install it yourself as:
 
 ## Usage
 
-`extend TinyHooks` in your class/module and you're all set to use `define_hook`!
+`include TinyHooks` in your class/module and you're all set to use `define_hook`!
 
 ```ruby
 class MyClass
-  extend TinyHooks
+  include TinyHooks
 
   def my_method
     puts 'my method'
@@ -47,7 +47,7 @@ You can halt hook and method body execution by `throw`ing `:abort`.
 
 ```ruby
 class MyClass
-  extend TinyHooks
+  include TinyHooks
 
   def my_method
     puts 'my method'
@@ -67,7 +67,7 @@ You can change how to halt from two options: throwing `:abort` and returning `fa
 
 ```ruby
 class MyClass
-  extend TinyHooks
+  include TinyHooks
 
   def my_method
     puts 'my method'

--- a/README.md
+++ b/README.md
@@ -82,6 +82,46 @@ MyClass.new.my_method
 # => ""
 ```
 
+### Targeting for hooks
+
+You can limit the targets for hooks in two ways. You can enable hooks for public methods only by using `public_only!` method and include/exclude targets with Regexp pattern by using `targets!` method.
+
+```ruby
+class MyClass
+  include TinyHooks
+
+  def my_method
+    puts 'my method'
+  end
+
+  private
+
+  def my_private_method
+    puts 'my private method'
+  end
+end
+
+class MyClassWithPublicOnly < MyClass
+  public_only!
+
+  define_hook :before, :my_private_method do
+    puts 'my_private_method'
+  end
+  # => This causes PrivateError
+end
+
+class MyClassWithExclude < MyClass
+  target! exclude_pattern: /my_method/
+
+  define_hook :before, :my_method do
+    puts 'my_method'
+  end
+  # => This causes TargetError
+end
+```
+
+You can call `include_private!` method to disable the effect of `public_only!`.
+
 ## Difference between TinyHooks and ActiveSupport::Callbacks
 
 While `TinyHooks` and `ActiveSupport::Callbacks` share the same purpose, there are a few major differences.

--- a/lib/tiny_hooks.rb
+++ b/lib/tiny_hooks.rb
@@ -10,15 +10,21 @@ module TinyHooks
 
   class PrivateError < Error; end
 
+  class TargetError < Error; end
+
   HALTING = Object.new.freeze
   private_constant :HALTING
+  UNDEFINED_TARGETS = [].freeze
+  private_constant :UNDEFINED_TARGETS
 
   # @api private
-  def self.extended(mod)
-    mod.class_eval do
-      @@_originals ||= {}
-      @@_public_only = false
+  def self.included(base)
+    base.class_eval do
+      @_originals = {}
+      @_targets = UNDEFINED_TARGETS
+      @_public_only = false
     end
+    base.extend ClassMethods
   end
 
   # @api private
@@ -34,105 +40,131 @@ module TinyHooks
     hook_result
   end
 
-  # Define hook with kind and target method
-  #
-  # @param [Symbol, String] kind the kind of the hook, possible values are: :before, :after and :around
-  # @param [Symbol, String] target the name of the targeted method
-  # @param [Symbol] terminator choice for terminating execution, default is throwing abort symbol
-  def define_hook(kind, target, terminator: :abort, &block)
-    raise ArgumentError, 'You must provide a block' unless block
-    raise ArgumentError, 'terminator must be one of the following: :abort or :return_false' unless %i[abort return_false].include? terminator.to_sym
+  # Class methods
+  module ClassMethods
+    # Define hook with kind and target method
+    #
+    # @param [Symbol, String] kind the kind of the hook, possible values are: :before, :after and :around
+    # @param [Symbol, String] target the name of the targeted method
+    # @param [Symbol] terminator choice for terminating execution, default is throwing abort symbol
+    def define_hook(kind, target, terminator: :abort, &block)
+      raise ArgumentError, 'You must provide a block' unless block
+      raise ArgumentError, 'terminator must be one of the following: :abort or :return_false' unless %i[abort return_false].include? terminator.to_sym
+      raise TinyHooks::TargetError, "Hook for #{target} is not allowed" if @_targets != UNDEFINED_TARGETS && !@_targets.include?(target)
 
-    begin
-      original_method = @@_public_only ? public_instance_method(target) : instance_method(target)
-    rescue NameError => e
-      raise unless e.message.include?('private')
+      begin
+        original_method = @_public_only ? public_instance_method(target) : instance_method(target)
+      rescue NameError => e
+        raise unless e.message.include?('private')
 
-      raise TinyHooks::PrivateError, "Public only mode is on and hooks for private methods (#{target} for this time) are not available."
-    end
-    @@_originals[target.to_sym] = original_method unless @@_originals[target.to_sym]
-
-    undef_method(target)
-    define_method(target, &method_body(kind, original_method, terminator, &block))
-  end
-
-  module_function :define_hook
-
-  # Restore original method
-  #
-  # @param [Symbol, String] target
-  def restore_original(target)
-    original_method = @@_originals[target.to_sym] || instance_method(target)
-
-    undef_method(target)
-    define_method(target, original_method)
-  end
-
-  # Enable public only mode
-  def public_only!
-    @@_public_only = true
-  end
-
-  # Disable public only mode
-  def include_private!
-    @@_public_only = false
-  end
-
-  private
-
-  def method_body(kind, original_method, terminator, &block)
-    case kind.to_sym
-    when :before then _before(original_method, terminator: terminator, &block)
-    when :after  then _after(original_method, &block)
-    when :around then _around(original_method, &block)
-    else
-      raise Error, "#{kind} is not supported."
-    end
-  end
-
-  def _before(original_method, terminator:, &block)
-    if RUBY_VERSION >= '2.7'
-      proc do |*args, **kwargs, &blk|
-        result = TinyHooks.with_halting(terminator, *args, **kwargs, &block)
-        return if result == HALTING
-
-        original_method.bind_call(self, *args, **kwargs, &blk)
+        raise TinyHooks::PrivateError, "Public only mode is on and hooks for private methods (#{target} for this time) are not available."
       end
-    else
-      proc do |*args, &blk|
-        result = TinyHooks.with_halting(terminator, *args, &block)
-        return if result == HALTING
+      @_originals[target.to_sym] = original_method unless @_originals[target.to_sym]
 
-        original_method.bind(self).call(*args, &blk)
-      end
+      undef_method(target)
+      define_method(target, &method_body(kind, original_method, terminator, &block))
     end
-  end
 
-  def _after(original_method, &block)
-    if RUBY_VERSION >= '2.7'
-      proc do |*args, **kwargs, &blk|
-        original_method.bind_call(self, *args, **kwargs, &blk)
-        instance_exec(*args, **kwargs, &block)
-      end
-    else
-      proc do |*args, &blk|
-        original_method.bind(self).call(*args, &blk)
-        instance_exec(*args, &block)
+    # Restore original method
+    #
+    # @param [Symbol, String] target
+    def restore_original(target)
+      original_method = @_originals[target.to_sym] || instance_method(target)
+
+      undef_method(target)
+      define_method(target, original_method)
+    end
+
+    # Defines target for hooks
+    # @param include_pattern [Regexp]
+    # @param exclude_pattern [Regexp]
+    def target!(include_pattern: nil, exclude_pattern: nil)
+      raise ArgumentError if include_pattern.nil? && exclude_pattern.nil?
+
+      candidates = @_public_only ? instance_methods : instance_methods + private_instance_methods
+      @_targets = if include_pattern && exclude_pattern
+                    targets = candidates.grep(include_pattern)
+                    targets.grep_v(exclude_pattern)
+                  elsif include_pattern
+                    candidates.grep(include_pattern)
+                  else
+                    candidates.grep_v(exclude_pattern)
+                  end
+    end
+
+    # Enable public only mode
+    def public_only!
+      @_public_only = true
+    end
+
+    # Disable public only mode
+    def include_private!
+      @_public_only = false
+    end
+
+    private
+
+    def method_body(kind, original_method, terminator, &block)
+      case kind.to_sym
+      when :before then _before(original_method, terminator: terminator, &block)
+      when :after  then _after(original_method, &block)
+      when :around then _around(original_method, &block)
+      else
+        raise Error, "#{kind} is not supported."
       end
     end
-  end
 
-  def _around(original_method, &block)
-    if RUBY_VERSION >= '2.7'
-      proc do |*args, **kwargs, &blk|
-        wrapper = -> { original_method.bind_call(self, *args, **kwargs, &blk) }
-        instance_exec(wrapper, *args, **kwargs, &block)
+    def _before(original_method, terminator:, &block)
+      if RUBY_VERSION >= '2.7'
+        proc do |*args, **kwargs, &blk|
+          result = TinyHooks.with_halting(terminator, *args, **kwargs, &block)
+          return if result == HALTING
+
+          original_method.bind_call(self, *args, **kwargs, &blk)
+        end
+      else
+        proc do |*args, &blk|
+          result = TinyHooks.with_halting(terminator, *args, &block)
+          return if result == HALTING
+
+          original_method.bind(self).call(*args, &blk)
+        end
       end
-    else
-      proc do |*args, &blk|
-        wrapper = -> { original_method.bind(self).call(*args, &blk) }
-        instance_exec(wrapper, *args, &block)
+    end
+
+    def _after(original_method, &block)
+      if RUBY_VERSION >= '2.7'
+        proc do |*args, **kwargs, &blk|
+          original_method.bind_call(self, *args, **kwargs, &blk)
+          instance_exec(*args, **kwargs, &block)
+        end
+      else
+        proc do |*args, &blk|
+          original_method.bind(self).call(*args, &blk)
+          instance_exec(*args, &block)
+        end
       end
+    end
+
+    def _around(original_method, &block)
+      if RUBY_VERSION >= '2.7'
+        proc do |*args, **kwargs, &blk|
+          wrapper = -> { original_method.bind_call(self, *args, **kwargs, &blk) }
+          instance_exec(wrapper, *args, **kwargs, &block)
+        end
+      else
+        proc do |*args, &blk|
+          wrapper = -> { original_method.bind(self).call(*args, &blk) }
+          instance_exec(wrapper, *args, &block)
+        end
+      end
+    end
+
+    def inherited(subclass)
+      super
+      subclass.instance_variable_set(:@_originals, instance_variable_get(:@_originals).clone)
+      subclass.instance_variable_set(:@_targets, instance_variable_get(:@_targets).clone)
+      subclass.instance_variable_set(:@_public_only, instance_variable_get(:@_public_only).clone)
     end
   end
 end

--- a/lib/tiny_hooks.rb
+++ b/lib/tiny_hooks.rb
@@ -52,6 +52,8 @@ module TinyHooks
       raise ArgumentError, 'terminator must be one of the following: :abort or :return_false' unless %i[abort return_false].include? terminator.to_sym
       raise TinyHooks::TargetError, "Hook for #{target} is not allowed" if @_targets != UNDEFINED_TARGETS && !@_targets.include?(target)
 
+      is_private = private_instance_methods.include?(target.to_sym)
+
       begin
         original_method = @_public_only ? public_instance_method(target) : instance_method(target)
       rescue NameError => e
@@ -63,6 +65,7 @@ module TinyHooks
 
       undef_method(target)
       define_method(target, &method_body(kind, original_method, terminator, &block))
+      private target if is_private
     end
 
     # Restore original method

--- a/test/tiny_hooks_test.rb
+++ b/test/tiny_hooks_test.rb
@@ -278,14 +278,14 @@ class TinyHooksTest < Minitest::Test
   end
 
   def test_when_it_includes_pattern_it_does_not_work_on_targets_against_pattern
-    defintion = <<~DEFINITION
+    definition = <<~DEFINITION
       class DForB < D1
         define_hook :before, :b do
           puts 'before b'
         end
       end
     DEFINITION
-    assert_raises(TinyHooks::TargetError) { eval(defintion) }
+    assert_raises(TinyHooks::TargetError) { eval(definition) }
   end
 
   class D3 < D
@@ -314,14 +314,14 @@ class TinyHooksTest < Minitest::Test
   end
 
   def test_when_it_excludes_pattern_it_does_not_work_on_targets_matching_pattern
-    defintion = <<~DEFINITION
+    definition = <<~DEFINITION
       class DForUnderscore < D3
         define_hook :before, :_b do
           puts 'before _b'
         end
       end
     DEFINITION
-    assert_raises(TinyHooks::TargetError) { eval(defintion) }
+    assert_raises(TinyHooks::TargetError) { eval(definition) }
   end
 
   class D5 < D
@@ -338,14 +338,14 @@ class TinyHooksTest < Minitest::Test
     d = D6.new
     assert_output("before b\nb\n") { d.b }
 
-    defintion = <<~DEFINITION
+    definition = <<~DEFINITION
       class DForUnderscoreB < D5
         define_hook :before, :_b do
           puts 'before _b'
         end
       end
     DEFINITION
-    assert_raises(TinyHooks::TargetError) { eval(defintion) }
+    assert_raises(TinyHooks::TargetError) { eval(definition) }
   end
 
   class E

--- a/test/tiny_hooks_test.rb
+++ b/test/tiny_hooks_test.rb
@@ -368,4 +368,19 @@ class TinyHooksTest < Minitest::Test
     e = E1.new
     assert_raises(NameError) { e.a }
   end
+
+  def test_it_raises_error_when_target_pattern_includes_method_but_it_is_private_and_public_only_is_called
+    definition = <<~DEFINITION
+      class EPublic < E
+        public_only!
+
+        target! include_pattern: /a/
+
+        define_hook :before, :a do
+          puts 'before a'
+        end
+      end
+    DEFINITION
+    assert_raises(TinyHooks::TargetError) { eval(definition) }
+  end
 end

--- a/test/tiny_hooks_test.rb
+++ b/test/tiny_hooks_test.rb
@@ -273,7 +273,7 @@ class TinyHooksTest < Minitest::Test
   def test_when_it_includes_pattern_it_works_on_targets_matching_pattern
     d = D2.new
     assert_output("before a\na\n") { d.a }
-    assert_output("before c\nc\n") { d.c }
+    assert_output("before c\nc\n") { d.__send__(:c) }
     assert_output("before _c\n_c\n") { d.__send__(:_c) }
   end
 
@@ -310,7 +310,7 @@ class TinyHooksTest < Minitest::Test
     d = D4.new
     assert_output("before a\na\n") { d.a }
     assert_output("before b\nb\n") { d.b }
-    assert_output("before c\nc\n") { d.c }
+    assert_output("before c\nc\n") { d.__send__(:c) }
   end
 
   def test_when_it_excludes_pattern_it_does_not_work_on_targets_matching_pattern
@@ -346,5 +346,26 @@ class TinyHooksTest < Minitest::Test
       end
     DEFINITION
     assert_raises(TinyHooks::TargetError) { eval(defintion) }
+  end
+
+  class E
+    include TinyHooks
+
+    private
+
+    def a
+      puts 'a'
+    end
+  end
+
+  class E1 < E
+    define_hook :before, :a do
+      puts 'before a'
+    end
+  end
+
+  def test_it_does_not_change_method_visibility
+    e = E1.new
+    assert_raises(NameError) { e.a }
   end
 end


### PR DESCRIPTION
IMPORTANT: now you must call `include TinyHooks` instead of `extend TinyHooks` to use TinyHooks.

In addition to interface change, this PR introduces:

- `target!` method to include/exclude hook targets with `Regexp` pattern
- `public_only!` to turn `public only mode` on
- `include_private!` to turn `public only mode` off

Close #3 