### PR TITLE
Fill placeholder in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/tiny_hooks. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/okuramasafumi/tiny_hooks/blob/main/CODE_OF_CONDUCT.md).
+Bug reports and pull requests are welcome on GitHub at https://github.com/okuramasafumi/tiny_hooks. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/okuramasafumi/tiny_hooks/blob/main/CODE_OF_CONDUCT.md).
 
 ## License
 


### PR DESCRIPTION
I recommend setting `github.user` to your `gitconfig`. "bundle gem" looks that value.

https://github.com/okuramasafumi/dotfiles/blob/master/git/gitconfig

https://github.com/rubygems/rubygems/blob/3df26a7dcb381cd8ed118fa7dcadab11abb13dcc/bundler/lib/bundler/cli/gem.rb#L45